### PR TITLE
ETH Payment & Buyback Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 ## Subgraphs
 
-* Abstract mainnet: [The Graph Network](https://thegraph.com/explorer/subgraphs/4aCcnWu6U2UhL6XrUKh2k45v4m8xVVF6S354PS2p9nsU?view=Query&chain=arbitrum-one) or [Goldsky](https://api.goldsky.com/api/public/project_cm3yp5wtflxub01wra3g2a0bc/subgraphs/noodles-abstract/v1.0.0/gn)
-* Abstract testnet: [The Graph Network](https://thegraph.com/explorer/subgraphs/3Z4xUtmadHbNTYpzk9d4pPpHJnsA9FXsYjwJx1aQ9zAC?v=19&view=Query&chain=arbitrum-one) or [Goldsky](https://api.goldsky.com/api/public/project_cm3yp5wtflxub01wra3g2a0bc/subgraphs/noodles-subgraph-testnet/0.3.3/gn)
+* Abstract mainnet: [The Graph Network - auto pruned](https://thegraph.com/explorer/subgraphs/4aCcnWu6U2UhL6XrUKh2k45v4m8xVVF6S354PS2p9nsU?view=Query&chain=arbitrum-one) or [Goldsky - no prune](https://api.goldsky.com/api/public/project_cm3yp5wtflxub01wra3g2a0bc/subgraphs/noodles-abstract/v1.1.0/gn)
+* Abstract testnet: [The Graph Network - auto pruned](https://api.studio.thegraph.com/query/94473/noodles-subgraph-testnet/version/latest) or [Goldsky - no prune](https://api.goldsky.com/api/public/project_cm3yp5wtflxub01wra3g2a0bc/subgraphs/noodles-subgraph-testnet/1.4.0/gn)
 
 ### Query example
 

--- a/abis/VisibilityCredits.json
+++ b/abis/VisibilityCredits.json
@@ -130,6 +130,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "SlippageError",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -453,9 +458,9 @@
     "name": "A",
     "outputs": [
       {
-        "internalType": "uint64",
+        "internalType": "uint16",
         "name": "",
-        "type": "uint64"
+        "type": "uint16"
       }
     ],
     "stateMutability": "view",
@@ -466,9 +471,9 @@
     "name": "B",
     "outputs": [
       {
-        "internalType": "uint64",
+        "internalType": "uint32",
         "name": "",
-        "type": "uint64"
+        "type": "uint32"
       }
     ],
     "stateMutability": "view",
@@ -479,9 +484,9 @@
     "name": "BASE_PRICE",
     "outputs": [
       {
-        "internalType": "uint64",
+        "internalType": "uint32",
         "name": "",
-        "type": "uint64"
+        "type": "uint32"
       }
     ],
     "stateMutability": "view",
@@ -583,9 +588,9 @@
     "name": "PARTNER_FEE",
     "outputs": [
       {
-        "internalType": "uint8",
+        "internalType": "uint16",
         "name": "",
-        "type": "uint8"
+        "type": "uint16"
       }
     ],
     "stateMutability": "view",
@@ -596,9 +601,9 @@
     "name": "PARTNER_REFERRER_BONUS",
     "outputs": [
       {
-        "internalType": "uint8",
+        "internalType": "uint16",
         "name": "",
-        "type": "uint8"
+        "type": "uint16"
       }
     ],
     "stateMutability": "view",
@@ -1229,6 +1234,11 @@
       {
         "internalType": "uint256",
         "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minExpectedWei",
         "type": "uint256"
       },
       {

--- a/abis/VisibilityServices.json
+++ b/abis/VisibilityServices.json
@@ -1,21 +1,9 @@
 [
-  {
-    "inputs": [],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "inputs": [],
-    "name": "AccessControlBadConfirmation",
-    "type": "error"
-  },
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  { "inputs": [], "name": "AccessControlBadConfirmation", "type": "error" },
   {
     "inputs": [
-      {
-        "internalType": "uint48",
-        "name": "schedule",
-        "type": "uint48"
-      }
+      { "internalType": "uint48", "name": "schedule", "type": "uint48" }
     ],
     "name": "AccessControlEnforcedDefaultAdminDelay",
     "type": "error"
@@ -27,133 +15,52 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "defaultAdmin",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "defaultAdmin", "type": "address" }
     ],
     "name": "AccessControlInvalidDefaultAdmin",
     "type": "error"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "neededRole",
-        "type": "bytes32"
-      }
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "bytes32", "name": "neededRole", "type": "bytes32" }
     ],
     "name": "AccessControlUnauthorizedAccount",
     "type": "error"
   },
-  {
-    "inputs": [],
-    "name": "DisabledService",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FailedCall",
-    "type": "error"
-  },
+  { "inputs": [], "name": "DisabledService", "type": "error" },
+  { "inputs": [], "name": "FailedCall", "type": "error" },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "balance",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "needed",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "balance", "type": "uint256" },
+      { "internalType": "uint256", "name": "needed", "type": "uint256" }
     ],
     "name": "InsufficientBalance",
     "type": "error"
   },
-  {
-    "inputs": [],
-    "name": "InsufficientValue",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidAddress",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidBuyBackCreditsShare",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidCreator",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidExecutionState",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidInitialization",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidOriginator",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidPaymentType",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidProtocolTreasury",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "NotInitializing",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "QuoteSlippage",
-    "type": "error"
-  },
+  { "inputs": [], "name": "InsufficientValue", "type": "error" },
+  { "inputs": [], "name": "InvalidAddress", "type": "error" },
+  { "inputs": [], "name": "InvalidBuyBackCreditsShare", "type": "error" },
+  { "inputs": [], "name": "InvalidCreator", "type": "error" },
+  { "inputs": [], "name": "InvalidExecutionNonce", "type": "error" },
+  { "inputs": [], "name": "InvalidExecutionState", "type": "error" },
+  { "inputs": [], "name": "InvalidInitialization", "type": "error" },
+  { "inputs": [], "name": "InvalidOriginator", "type": "error" },
+  { "inputs": [], "name": "InvalidPayloadDataSize", "type": "error" },
+  { "inputs": [], "name": "InvalidPaymentType", "type": "error" },
+  { "inputs": [], "name": "InvalidProtocolTreasury", "type": "error" },
+  { "inputs": [], "name": "InvalidValue", "type": "error" },
+  { "inputs": [], "name": "NotInitializing", "type": "error" },
+  { "inputs": [], "name": "QuoteSlippage", "type": "error" },
   {
     "inputs": [
-      {
-        "internalType": "uint8",
-        "name": "bits",
-        "type": "uint8"
-      },
-      {
-        "internalType": "uint256",
-        "name": "value",
-        "type": "uint256"
-      }
+      { "internalType": "uint8", "name": "bits", "type": "uint8" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
     ],
     "name": "SafeCastOverflowedUintDowncast",
     "type": "error"
   },
-  {
-    "inputs": [],
-    "name": "UnauthorizedExecutionAction",
-    "type": "error"
-  },
+  { "inputs": [], "name": "UnauthorizedExecutionAction", "type": "error" },
   {
     "anonymous": false,
     "inputs": [
@@ -489,6 +396,12 @@
         "type": "uint256"
       },
       {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "executionNonce",
+        "type": "uint256"
+      },
+      {
         "indexed": false,
         "internalType": "uint256",
         "name": "protocolAmount",
@@ -705,65 +618,35 @@
   {
     "inputs": [],
     "name": "AUTO_VALIDATION_DELAY",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "DEFAULT_ADMIN_ROLE",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "DISPUTE_RESOLVER_ROLE",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "FEE_DENOMINATOR",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "PROTOCOL_FEE",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -776,21 +659,13 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "executionNonce",
         "type": "uint256"
       },
-      {
-        "internalType": "string",
-        "name": "responseData",
-        "type": "string"
-      }
+      { "internalType": "string", "name": "responseData", "type": "string" }
     ],
     "name": "acceptServiceExecution",
     "outputs": [],
@@ -799,21 +674,13 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "executionNonce",
         "type": "uint256"
       },
-      {
-        "internalType": "string",
-        "name": "informationData",
-        "type": "string"
-      }
+      { "internalType": "string", "name": "informationData", "type": "string" }
     ],
     "name": "addInformationForServiceExecution",
     "outputs": [],
@@ -822,11 +689,7 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "newAdmin", "type": "address" }
     ],
     "name": "beginDefaultAdminTransfer",
     "outputs": [],
@@ -835,21 +698,9 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "string",
-        "name": "visibilityId",
-        "type": "string"
-      },
-      {
-        "internalType": "uint256",
-        "name": "creditsAmount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "maxWeiAmount",
-        "type": "uint256"
-      }
+      { "internalType": "string", "name": "visibilityId", "type": "string" },
+      { "internalType": "uint256", "name": "creditsAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "maxWeiAmount", "type": "uint256" }
     ],
     "name": "buyBack",
     "outputs": [],
@@ -865,21 +716,13 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "executionNonce",
         "type": "uint256"
       },
-      {
-        "internalType": "string",
-        "name": "cancelData",
-        "type": "string"
-      }
+      { "internalType": "string", "name": "cancelData", "type": "string" }
     ],
     "name": "cancelServiceExecution",
     "outputs": [],
@@ -888,11 +731,7 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint48",
-        "name": "newDelay",
-        "type": "uint48"
-      }
+      { "internalType": "uint48", "name": "newDelay", "type": "uint48" }
     ],
     "name": "changeDefaultAdminDelay",
     "outputs": [],
@@ -901,16 +740,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "costAmount",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
+      { "internalType": "uint256", "name": "costAmount", "type": "uint256" }
     ],
     "name": "createAndUpdateFromService",
     "outputs": [],
@@ -919,16 +750,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "string",
-        "name": "serviceType",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "visibilityId",
-        "type": "string"
-      },
+      { "internalType": "string", "name": "serviceType", "type": "string" },
+      { "internalType": "string", "name": "visibilityId", "type": "string" },
       {
         "internalType": "uint256",
         "name": "creditsCostAmount",
@@ -942,26 +765,14 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "string",
-        "name": "serviceType",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "visibilityId",
-        "type": "string"
-      },
+      { "internalType": "string", "name": "serviceType", "type": "string" },
+      { "internalType": "string", "name": "visibilityId", "type": "string" },
       {
         "internalType": "uint256",
         "name": "buyBackCreditsShare",
         "type": "uint256"
       },
-      {
-        "internalType": "uint256",
-        "name": "weiCostAmount",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "weiCostAmount", "type": "uint256" }
     ],
     "name": "createServiceWithETH",
     "outputs": [],
@@ -971,59 +782,33 @@
   {
     "inputs": [],
     "name": "defaultAdmin",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "defaultAdminDelay",
-    "outputs": [
-      {
-        "internalType": "uint48",
-        "name": "",
-        "type": "uint48"
-      }
-    ],
+    "outputs": [{ "internalType": "uint48", "name": "", "type": "uint48" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "defaultAdminDelayIncreaseWait",
-    "outputs": [
-      {
-        "internalType": "uint48",
-        "name": "",
-        "type": "uint48"
-      }
-    ],
+    "outputs": [{ "internalType": "uint48", "name": "", "type": "uint48" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "executionNonce",
         "type": "uint256"
       },
-      {
-        "internalType": "string",
-        "name": "disputeData",
-        "type": "string"
-      }
+      { "internalType": "string", "name": "disputeData", "type": "string" }
     ],
     "name": "disputeServiceExecution",
     "outputs": [],
@@ -1032,48 +817,22 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      }
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
     ],
     "name": "getRoleAdmin",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" }
     ],
     "name": "getService",
     "outputs": [
-      {
-        "internalType": "bool",
-        "name": "enabled",
-        "type": "bool"
-      },
-      {
-        "internalType": "string",
-        "name": "serviceType",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "visibilityId",
-        "type": "string"
-      },
+      { "internalType": "bool", "name": "enabled", "type": "bool" },
+      { "internalType": "string", "name": "serviceType", "type": "string" },
+      { "internalType": "string", "name": "visibilityId", "type": "string" },
       {
         "internalType": "uint256",
         "name": "creditsCostAmount",
@@ -1084,16 +843,8 @@
         "name": "executionsNonce",
         "type": "uint256"
       },
-      {
-        "internalType": "address",
-        "name": "originator",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "weiCostAmount",
-        "type": "uint256"
-      },
+      { "internalType": "address", "name": "originator", "type": "address" },
+      { "internalType": "uint256", "name": "weiCostAmount", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "buyBackCreditsShare",
@@ -1110,16 +861,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "executionNonce",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
+      { "internalType": "uint256", "name": "executionNonce", "type": "uint256" }
     ],
     "name": "getServiceExecution",
     "outputs": [
@@ -1128,11 +871,7 @@
         "name": "state",
         "type": "uint8"
       },
-      {
-        "internalType": "address",
-        "name": "requester",
-        "type": "address"
-      },
+      { "internalType": "address", "name": "requester", "type": "address" },
       {
         "internalType": "uint256",
         "name": "lastUpdateTimestamp",
@@ -1144,48 +883,24 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "string",
-        "name": "visibilityId",
-        "type": "string"
-      }
+      { "internalType": "string", "name": "visibilityId", "type": "string" }
     ],
     "name": "getVisibilityBuyBackEthBalance",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "getVisibilityCreditsContract",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
     ],
     "name": "grantRole",
     "outputs": [],
@@ -1194,25 +909,11 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
     ],
     "name": "hasRole",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -1223,16 +924,8 @@
         "name": "visibilityCredits",
         "type": "address"
       },
-      {
-        "internalType": "uint48",
-        "name": "adminDelay",
-        "type": "uint48"
-      },
-      {
-        "internalType": "address",
-        "name": "admin",
-        "type": "address"
-      },
+      { "internalType": "uint48", "name": "adminDelay", "type": "uint48" },
+      { "internalType": "address", "name": "admin", "type": "address" },
       {
         "internalType": "address",
         "name": "disputeResolver",
@@ -1247,13 +940,7 @@
   {
     "inputs": [],
     "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -1261,16 +948,8 @@
     "inputs": [],
     "name": "pendingDefaultAdmin",
     "outputs": [
-      {
-        "internalType": "address",
-        "name": "newAdmin",
-        "type": "address"
-      },
-      {
-        "internalType": "uint48",
-        "name": "schedule",
-        "type": "uint48"
-      }
+      { "internalType": "address", "name": "newAdmin", "type": "address" },
+      { "internalType": "uint48", "name": "schedule", "type": "uint48" }
     ],
     "stateMutability": "view",
     "type": "function"
@@ -1279,32 +958,16 @@
     "inputs": [],
     "name": "pendingDefaultAdminDelay",
     "outputs": [
-      {
-        "internalType": "uint48",
-        "name": "newDelay",
-        "type": "uint48"
-      },
-      {
-        "internalType": "uint48",
-        "name": "schedule",
-        "type": "uint48"
-      }
+      { "internalType": "uint48", "name": "newDelay", "type": "uint48" },
+      { "internalType": "uint48", "name": "schedule", "type": "uint48" }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
     ],
     "name": "renounceRole",
     "outputs": [],
@@ -1313,16 +976,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
-      {
-        "internalType": "string",
-        "name": "requestData",
-        "type": "string"
-      }
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
+      { "internalType": "string", "name": "requestData", "type": "string" }
     ],
     "name": "requestServiceExecution",
     "outputs": [],
@@ -1331,26 +986,14 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "executionNonce",
         "type": "uint256"
       },
-      {
-        "internalType": "bool",
-        "name": "refund",
-        "type": "bool"
-      },
-      {
-        "internalType": "string",
-        "name": "resolveData",
-        "type": "string"
-      }
+      { "internalType": "bool", "name": "refund", "type": "bool" },
+      { "internalType": "string", "name": "resolveData", "type": "string" }
     ],
     "name": "resolveServiceExecution",
     "outputs": [],
@@ -1359,16 +1002,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
     ],
     "name": "revokeRole",
     "outputs": [],
@@ -1384,30 +1019,16 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes4",
-        "name": "interfaceId",
-        "type": "bytes4"
-      }
+      { "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }
     ],
     "name": "supportsInterface",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
       {
         "internalType": "uint256",
         "name": "buyBackCreditsShare",
@@ -1421,16 +1042,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "enabled",
-        "type": "bool"
-      }
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
+      { "internalType": "bool", "name": "enabled", "type": "bool" }
     ],
     "name": "updateService",
     "outputs": [],
@@ -1439,16 +1052,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "serviceNonce",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "executionNonce",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "serviceNonce", "type": "uint256" },
+      { "internalType": "uint256", "name": "executionNonce", "type": "uint256" }
     ],
     "name": "validateServiceExecution",
     "outputs": [],

--- a/abis/VisibilityServices.json
+++ b/abis/VisibilityServices.json
@@ -489,6 +489,37 @@
         "type": "uint256"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "protocolAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "creatorAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "buyBackAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ServiceExecutionEthPayment",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "serviceNonce",
+        "type": "uint256"
+      },
+      {
         "indexed": true,
         "internalType": "uint256",
         "name": "executionNonce",

--- a/abis/VisibilityServices.json
+++ b/abis/VisibilityServices.json
@@ -59,7 +59,38 @@
   },
   {
     "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientValue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidBuyBackCreditsShare",
     "type": "error"
   },
   {
@@ -84,7 +115,22 @@
   },
   {
     "inputs": [],
+    "name": "InvalidPaymentType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProtocolTreasury",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "QuoteSlippage",
     "type": "error"
   },
   {
@@ -107,6 +153,56 @@
     "inputs": [],
     "name": "UnauthorizedExecutionAction",
     "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "visibilityId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalWeiCost",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "creditsAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "BuyBack",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "visibilityId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isBuyBack",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "weiAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "BuyBackPoolUpdated",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -244,6 +340,25 @@
       }
     ],
     "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "buyBackCreditsShare",
+        "type": "uint256"
+      }
+    ],
+    "name": "ServiceBuyBackUpdated",
     "type": "event"
   },
   {
@@ -514,6 +629,49 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "originator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "serviceType",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "visibilityId",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "buyBackCreditsShare",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "weiCostAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ServiceWithETHCreated",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "AUTO_VALIDATION_DELAY",
     "outputs": [
@@ -547,6 +705,32 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FEE_DENOMINATOR",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PROTOCOL_FEE",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
       }
     ],
     "stateMutability": "view",
@@ -619,6 +803,29 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "visibilityId",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "creditsAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxWeiAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyBack",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "cancelDefaultAdminTransfer",
     "outputs": [],
@@ -670,7 +877,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "creditsCostAmount",
+        "name": "costAmount",
         "type": "uint256"
       }
     ],
@@ -698,6 +905,34 @@
       }
     ],
     "name": "createService",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "serviceType",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "visibilityId",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buyBackCreditsShare",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "weiCostAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "createServiceWithETH",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -817,6 +1052,26 @@
         "internalType": "uint256",
         "name": "executionsNonce",
         "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "originator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "weiCostAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buyBackCreditsShare",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum IVisibilityServices.PaymentType",
+        "name": "paymentType",
+        "type": "uint8"
       }
     ],
     "stateMutability": "view",
@@ -850,6 +1105,25 @@
       {
         "internalType": "uint256",
         "name": "lastUpdateTimestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "visibilityId",
+        "type": "string"
+      }
+    ],
+    "name": "getVisibilityBuyBackEthBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
         "type": "uint256"
       }
     ],
@@ -1021,7 +1295,7 @@
     ],
     "name": "requestServiceExecution",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -1094,6 +1368,24 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "serviceNonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "buyBackCreditsShare",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateBuyBackCreditsShare",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "noodles-subgraph",
-  "version": "0.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "noodles-subgraph",
-      "version": "0.2.1",
+      "version": "1.3.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@graphprotocol/graph-cli": "^0.95.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.1",
+  "version": "1.4.0",
   "name": "noodles-subgraph",
   "license": "UNLICENSED",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.3.0",
   "name": "noodles-subgraph",
   "license": "UNLICENSED",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.3.1",
   "name": "noodles-subgraph",
   "license": "UNLICENSED",
   "scripts": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -108,6 +108,8 @@ type VisibilityService @entity {
   weiCostAmount: BigInt! # uint256
   buyBackCreditsShare: BigInt! # uint256
   executions: [VisibilityServiceExecution!]! @derivedFrom(field: "service")
+  serviceExecutionEthPayments: [ServiceExecutionEthPayment!]!
+    @derivedFrom(field: "service")
 }
 
 type VisibilityServiceExecution @entity {
@@ -277,6 +279,17 @@ type ServiceExecutionDisputed @entity(immutable: true) {
   serviceNonce: BigInt! # uint256
   executionNonce: BigInt! # uint256
   disputeData: String! # string
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type ServiceExecutionEthPayment @entity(immutable: true) {
+  id: Bytes!
+  service: VisibilityService! # serviceNonce
+  protocolAmount: BigInt! # uint256
+  creatorAmount: BigInt! # uint256
+  buyBackAmount: BigInt! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,6 +7,12 @@ enum ExecutionState {
   VALIDATED
 }
 
+enum PaymentType {
+  VISIBILITY_CREDITS # Legacy
+  ETH
+  ERC20 # further implementation
+}
+
 ####################
 ## Model entities ##
 ####################
@@ -74,7 +80,9 @@ type Visibility @entity {
   currentPrice: BigInt! # uint256
   totalSupply: BigInt! # uint256
   claimableFeeBalance: BigInt! # uint256
+  buyBackEthBalance: BigInt! # uint256
   balances: [VisibilityBalance!]! @derivedFrom(field: "visibility")
+  buyBacks: [BuyBack!]! @derivedFrom(field: "visibility")
   trades: [CreditsTrade!]! @derivedFrom(field: "visibility")
   services: [VisibilityService!]! @derivedFrom(field: "visibility")
 }
@@ -91,11 +99,14 @@ type VisibilityBalance @entity {
 type VisibilityService @entity {
   id: Bytes! # serviceNonce
   serviceNonce: BigInt! # uint256
+  paymentType: PaymentType! # enum
   originator: User! # address
   visibility: Visibility!
   serviceType: String! # string
   creditsCostAmount: BigInt! # uint256
   enabled: Boolean! # bool
+  weiCostAmount: BigInt! # uint256
+  buyBackCreditsShare: BigInt! # uint256
   executions: [VisibilityServiceExecution!]! @derivedFrom(field: "service")
 }
 
@@ -119,6 +130,26 @@ type VisibilityServiceExecution @entity {
 #####################
 ## Events entities ##
 #####################
+
+type BuyBack @entity(immutable: true) {
+  id: Bytes!
+  visibility: Visibility!
+  weiCost: BigInt! # uint256
+  creditsAmount: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type BuyBackPoolUpdated @entity(immutable: true) {
+  id: Bytes!
+  visibility: Visibility!
+  isBuyBack: Boolean! # bool
+  weiAmount: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
 
 type CreditsTrade @entity(timeseries: true) {
   id: Int8!
@@ -186,12 +217,35 @@ type ReferrerPartnerSet @entity(immutable: true) {
   transactionHash: Bytes!
 }
 
+type ServiceBuyBackUpdated @entity(immutable: true) {
+  id: Bytes!
+  nonce: BigInt! # uint256
+  buyBackCreditsShare: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
 type ServiceCreated @entity(immutable: true) {
   id: Bytes!
+  originator: User! # userAddress
   nonce: BigInt! # uint256
   serviceType: String! # string
   visibility: Visibility!
   creditsCostAmount: BigInt! # uint256
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type ServiceWithETHCreated @entity(immutable: true) {
+  id: Bytes!
+  originator: User! # userAddress
+  nonce: BigInt! # uint256
+  serviceType: String! # string
+  visibility: Visibility!
+  buyBackCreditsShare: BigInt! # uint256
+  weiCostAmount: BigInt! # uint256
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!

--- a/schema.graphql
+++ b/schema.graphql
@@ -125,6 +125,7 @@ type VisibilityServiceExecution @entity {
   disputeData: String # string
   resolveData: String # string
   lastUpdated: BigInt! # uint256
+  ethPayment: ServiceExecutionEthPayment
   informations: [ServiceExecutionInformation!]!
     @derivedFrom(field: "serviceExecution")
 }

--- a/src/visibility-credits.ts
+++ b/src/visibility-credits.ts
@@ -382,9 +382,6 @@ export function handleCreditsTrade(event: CreditsTradeEvent): void {
   date.setUTCSeconds(0)
   date.setUTCMinutes(0)
   date.setUTCHours(0)
-  let day = date.getUTCDate()
-  let month = date.getUTCMonth() + 1
-  let year = date.getUTCFullYear()
   let formattedDate = date.toISOString().split('T')[0]
   let dayTimestamp = date.getTime()
 

--- a/src/visibility-credits.ts
+++ b/src/visibility-credits.ts
@@ -192,6 +192,7 @@ export function handleCreatorVisibilitySet(
     visibility.currentPrice = BigInt.fromI32(0)
     visibility.totalSupply = BigInt.fromI32(0)
     visibility.claimableFeeBalance = BigInt.fromI32(0)
+    visibility.buyBackEthBalance = BigInt.fromI32(0)
   }
 
   let creator: User | null = null
@@ -246,6 +247,7 @@ export function handleCreditsTrade(event: CreditsTradeEvent): void {
     )
     visibility.visibilityId = event.params.tradeEvent.visibilityId
     visibility.claimableFeeBalance = BigInt.fromI32(0)
+    visibility.buyBackEthBalance = BigInt.fromI32(0)
   }
   visibility.currentPrice = computeNewCurrentPrice(
     event.params.tradeEvent.newTotalSupply
@@ -591,6 +593,7 @@ export function handleCreditsTransfer(event: CreditsTransferEvent): void {
     visibility.currentPrice = BigInt.fromI32(0)
     visibility.totalSupply = BigInt.fromI32(0)
     visibility.claimableFeeBalance = BigInt.fromI32(0)
+    visibility.buyBackEthBalance = BigInt.fromI32(0)
   }
   visibility.save()
 

--- a/src/visibility-services.ts
+++ b/src/visibility-services.ts
@@ -8,6 +8,7 @@ import {
   ServiceExecutionAccepted as ServiceExecutionAcceptedEvent,
   ServiceExecutionCanceled as ServiceExecutionCanceledEvent,
   ServiceExecutionDisputed as ServiceExecutionDisputedEvent,
+  ServiceExecutionEthPayment as ServiceExecutionEthPaymentEvent,
   ServiceExecutionInformation as ServiceExecutionInformationEvent,
   ServiceExecutionRequested as ServiceExecutionRequestedEvent,
   ServiceExecutionResolved as ServiceExecutionResolvedEvent,
@@ -23,6 +24,7 @@ import {
   ServiceExecutionAccepted,
   ServiceExecutionCanceled,
   ServiceExecutionDisputed,
+  ServiceExecutionEthPayment,
   ServiceExecutionInformation,
   ServiceExecutionRequested,
   ServiceExecutionResolved,
@@ -370,6 +372,34 @@ export function handleServiceExecutionDisputed(
   entity.transactionHash = event.transaction.hash
 
   entity.save()
+}
+
+export function handleServiceExecutionEthPayment(
+  event: ServiceExecutionEthPaymentEvent
+): void {
+  let visibilityService = VisibilityService.load(
+    Bytes.fromUTF8(event.params.serviceNonce.toString())
+  )
+  if (!visibilityService) {
+    visibilityService = VisibilityService.loadInBlock(
+      Bytes.fromUTF8(event.params.serviceNonce.toString())
+    )
+  }
+  if (visibilityService) {
+    let entity = new ServiceExecutionEthPayment(
+      event.transaction.hash.concatI32(event.logIndex.toI32())
+    )
+    entity.service = visibilityService.id
+    entity.protocolAmount = event.params.protocolAmount
+    entity.creatorAmount = event.params.creatorAmount
+    entity.buyBackAmount = event.params.buyBackAmount
+
+    entity.blockNumber = event.block.number
+    entity.blockTimestamp = event.block.timestamp
+    entity.transactionHash = event.transaction.hash
+
+    entity.save()
+  }
 }
 
 export function handleServiceExecutionInformation(

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -78,7 +78,7 @@ dataSources:
           handler: handleServiceExecutionCanceled
         - event: ServiceExecutionDisputed(indexed uint256,indexed uint256,string)
           handler: handleServiceExecutionDisputed
-        - event: ServiceExecutionEthPayment(indexed uint256,uint256,uint256,uint256)
+        - event: ServiceExecutionEthPayment(indexed uint256,indexed uint256,uint256,uint256,uint256)
           handler: handleServiceExecutionEthPayment
         - event: ServiceExecutionRequested(indexed uint256,indexed uint256,indexed address,string)
           handler: handleServiceExecutionRequested

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -60,8 +60,16 @@ dataSources:
         - name: VisibilityServices
           file: ./abis/VisibilityServices.json
       eventHandlers:
+        - event: BuyBack(string,uint256,uint256)
+          handler: handleBuyBack
+        - event: BuyBackPoolUpdated(string,bool,uint256)
+          handler: handleBuyBackPoolUpdated
+        - event: ServiceBuyBackUpdated(indexed uint256,uint256)
+          handler: handleServiceBuyBackUpdated
         - event: ServiceCreated(indexed address,indexed uint256,string,string,uint256)
           handler: handleServiceCreated
+        - event: ServiceWithETHCreated(indexed address,indexed uint256,string,string,uint256,uint256)
+          handler: handleServiceWithETHCreated
         - event: ServiceExecutionInformation(indexed uint256,indexed uint256,indexed address,bool,bool,bool,string)
           handler: handleServiceExecutionInformation
         - event: ServiceExecutionAccepted(indexed uint256,indexed uint256,string)

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -78,6 +78,8 @@ dataSources:
           handler: handleServiceExecutionCanceled
         - event: ServiceExecutionDisputed(indexed uint256,indexed uint256,string)
           handler: handleServiceExecutionDisputed
+        - event: ServiceExecutionEthPayment(indexed uint256,uint256,uint256,uint256)
+          handler: handleServiceExecutionEthPayment
         - event: ServiceExecutionRequested(indexed uint256,indexed uint256,indexed address,string)
           handler: handleServiceExecutionRequested
         - event: ServiceExecutionResolved(indexed uint256,indexed uint256,bool,string)

--- a/subgraph.testnet.yaml
+++ b/subgraph.testnet.yaml
@@ -78,7 +78,7 @@ dataSources:
           handler: handleServiceExecutionCanceled
         - event: ServiceExecutionDisputed(indexed uint256,indexed uint256,string)
           handler: handleServiceExecutionDisputed
-        - event: ServiceExecutionEthPayment(indexed uint256,uint256,uint256,uint256)
+        - event: ServiceExecutionEthPayment(indexed uint256,indexed uint256,uint256,uint256,uint256)
           handler: handleServiceExecutionEthPayment
         - event: ServiceExecutionRequested(indexed uint256,indexed uint256,indexed address,string)
           handler: handleServiceExecutionRequested

--- a/subgraph.testnet.yaml
+++ b/subgraph.testnet.yaml
@@ -60,8 +60,16 @@ dataSources:
         - name: VisibilityServices
           file: ./abis/VisibilityServices.json
       eventHandlers:
+        - event: BuyBack(string,uint256,uint256)
+          handler: handleBuyBack
+        - event: BuyBackPoolUpdated(string,bool,uint256)
+          handler: handleBuyBackPoolUpdated
+        - event: ServiceBuyBackUpdated(indexed uint256,uint256)
+          handler: handleServiceBuyBackUpdated
         - event: ServiceCreated(indexed address,indexed uint256,string,string,uint256)
           handler: handleServiceCreated
+        - event: ServiceWithETHCreated(indexed address,indexed uint256,string,string,uint256,uint256)
+          handler: handleServiceWithETHCreated
         - event: ServiceExecutionInformation(indexed uint256,indexed uint256,indexed address,bool,bool,bool,string)
           handler: handleServiceExecutionInformation
         - event: ServiceExecutionAccepted(indexed uint256,indexed uint256,string)

--- a/subgraph.testnet.yaml
+++ b/subgraph.testnet.yaml
@@ -78,6 +78,8 @@ dataSources:
           handler: handleServiceExecutionCanceled
         - event: ServiceExecutionDisputed(indexed uint256,indexed uint256,string)
           handler: handleServiceExecutionDisputed
+        - event: ServiceExecutionEthPayment(indexed uint256,uint256,uint256,uint256)
+          handler: handleServiceExecutionEthPayment
         - event: ServiceExecutionRequested(indexed uint256,indexed uint256,indexed address,string)
           handler: handleServiceExecutionRequested
         - event: ServiceExecutionResolved(indexed uint256,indexed uint256,bool,string)

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -78,7 +78,7 @@ dataSources:
           handler: handleServiceExecutionCanceled
         - event: ServiceExecutionDisputed(indexed uint256,indexed uint256,string)
           handler: handleServiceExecutionDisputed
-        - event: ServiceExecutionEthPayment(indexed uint256,uint256,uint256,uint256)
+        - event: ServiceExecutionEthPayment(indexed uint256,indexed uint256,uint256,uint256,uint256)
           handler: handleServiceExecutionEthPayment
         - event: ServiceExecutionRequested(indexed uint256,indexed uint256,indexed address,string)
           handler: handleServiceExecutionRequested

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,16 +1,16 @@
 specVersion: 1.1.0
 indexerHints:
-  prune: auto
+  prune: never
 schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum
     name: VisibilityCredits
-    network: abstract
+    network: abstract-testnet
     source:
-      address: "0x0DA6Bfd5d50edb31AF14C3A7820d28dB475Ec97D"
+      address: "0x25aaca9fD684CD710BB87bd8f87A2a9F20e5a269"
       abi: VisibilityCredits
-      startBlock: 1430938
+      startBlock: 5500360
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -38,11 +38,11 @@ dataSources:
       file: ./src/visibility-credits.ts
   - kind: ethereum
     name: VisibilityServices
-    network: abstract
+    network: abstract-testnet
     source:
       abi: VisibilityServices
-      address: "0x89e74F963e506D6921FF33cB75b53b963D7218bE"
-      startBlock: 1430938
+      address: "0x446aC2A937b7ef299402D97a9132CD2ce7Ff73b1"
+      startBlock: 5500360
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -89,11 +89,11 @@ dataSources:
       file: ./src/visibility-services.ts
   - kind: ethereum
     name: PointsSBT
-    network: abstract
+    network: abstract-testnet
     source:
-      address: "0xE19FF0aCF99fc4598003d34E8DF7b828849B9F48"
+      address: "0x53D523F98dFd0B4b8ADd9306D345d6e709AD6b18"
       abi: PointsSBT
-      startBlock: 1430938
+      startBlock: 5500360
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -60,8 +60,16 @@ dataSources:
         - name: VisibilityServices
           file: ./abis/VisibilityServices.json
       eventHandlers:
+        - event: BuyBack(string,uint256,uint256)
+          handler: handleBuyBack
+        - event: BuyBackPoolUpdated(string,bool,uint256)
+          handler: handleBuyBackPoolUpdated
+        - event: ServiceBuyBackUpdated(indexed uint256,uint256)
+          handler: handleServiceBuyBackUpdated
         - event: ServiceCreated(indexed address,indexed uint256,string,string,uint256)
           handler: handleServiceCreated
+        - event: ServiceWithETHCreated(indexed address,indexed uint256,string,string,uint256,uint256)
+          handler: handleServiceWithETHCreated
         - event: ServiceExecutionInformation(indexed uint256,indexed uint256,indexed address,bool,bool,bool,string)
           handler: handleServiceExecutionInformation
         - event: ServiceExecutionAccepted(indexed uint256,indexed uint256,string)

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -78,6 +78,8 @@ dataSources:
           handler: handleServiceExecutionCanceled
         - event: ServiceExecutionDisputed(indexed uint256,indexed uint256,string)
           handler: handleServiceExecutionDisputed
+        - event: ServiceExecutionEthPayment(indexed uint256,uint256,uint256,uint256)
+          handler: handleServiceExecutionEthPayment
         - event: ServiceExecutionRequested(indexed uint256,indexed uint256,indexed address,string)
           handler: handleServiceExecutionRequested
         - event: ServiceExecutionResolved(indexed uint256,indexed uint256,bool,string)

--- a/tests/visibility-services-utils.ts
+++ b/tests/visibility-services-utils.ts
@@ -1,7 +1,11 @@
 import { newMockEvent } from 'matchstick-as'
 import { ethereum, BigInt, Address, Bytes } from '@graphprotocol/graph-ts'
 import {
+  BuyBack,
+  BuyBackPoolUpdated,
+  ServiceBuyBackUpdated,
   ServiceCreated,
+  ServiceWithETHCreated,
   ServiceExecutionAccepted,
   ServiceExecutionCanceled,
   ServiceExecutionDisputed,
@@ -11,6 +15,87 @@ import {
   ServiceExecutionValidated,
   ServiceUpdated
 } from '../generated/VisibilityServices/VisibilityServices'
+
+export function createBuyBackEvent(
+  visibilityId: string,
+  totalWeiCost: BigInt,
+  creditsAmount: BigInt
+): BuyBack {
+  let buyBackEvent = changetype<BuyBack>(newMockEvent())
+
+  buyBackEvent.parameters = new Array()
+
+  buyBackEvent.parameters.push(
+    new ethereum.EventParam(
+      'visibilityId',
+      ethereum.Value.fromString(visibilityId)
+    )
+  )
+  buyBackEvent.parameters.push(
+    new ethereum.EventParam(
+      'totalWeiCost',
+      ethereum.Value.fromUnsignedBigInt(totalWeiCost)
+    )
+  )
+  buyBackEvent.parameters.push(
+    new ethereum.EventParam(
+      'creditsAmount',
+      ethereum.Value.fromUnsignedBigInt(creditsAmount)
+    )
+  )
+
+  return buyBackEvent
+}
+
+export function createBuyBackPoolUpdatedEvent(
+  visibilityId: string,
+  isBuyBack: boolean,
+  weiAmount: BigInt
+): BuyBackPoolUpdated {
+  let buyBackPoolUpdatedEvent = changetype<BuyBackPoolUpdated>(newMockEvent())
+
+  buyBackPoolUpdatedEvent.parameters = new Array()
+
+  buyBackPoolUpdatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'visibilityId',
+      ethereum.Value.fromString(visibilityId)
+    )
+  )
+  buyBackPoolUpdatedEvent.parameters.push(
+    new ethereum.EventParam('isBuyBack', ethereum.Value.fromBoolean(isBuyBack))
+  )
+  buyBackPoolUpdatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'weiAmount',
+      ethereum.Value.fromUnsignedBigInt(weiAmount)
+    )
+  )
+
+  return buyBackPoolUpdatedEvent
+}
+
+export function createServiceBuyBackUpdatedEvent(
+  nonce: BigInt,
+  buyBackCreditsShare: BigInt
+): ServiceBuyBackUpdated {
+  let serviceBuyBackUpdatedEvent =
+    changetype<ServiceBuyBackUpdated>(newMockEvent())
+
+  serviceBuyBackUpdatedEvent.parameters = new Array()
+
+  serviceBuyBackUpdatedEvent.parameters.push(
+    new ethereum.EventParam('nonce', ethereum.Value.fromUnsignedBigInt(nonce))
+  )
+  serviceBuyBackUpdatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'buyBackCreditsShare',
+      ethereum.Value.fromUnsignedBigInt(buyBackCreditsShare)
+    )
+  )
+
+  return serviceBuyBackUpdatedEvent
+}
 
 export function createServiceCreatedEvent(
   originator: Address,
@@ -53,6 +138,57 @@ export function createServiceCreatedEvent(
   )
 
   return serviceCreatedEvent
+}
+
+export function createServiceWithETHCreatedEvent(
+  originator: Address,
+  nonce: BigInt,
+  serviceType: string,
+  visibilityId: string,
+  buyBackCreditsShare: BigInt,
+  weiCostAmount: BigInt
+): ServiceWithETHCreated {
+  let serviceWithETHCreatedEvent =
+    changetype<ServiceWithETHCreated>(newMockEvent())
+
+  serviceWithETHCreatedEvent.parameters = new Array()
+
+  serviceWithETHCreatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'originator',
+      ethereum.Value.fromAddress(originator)
+    )
+  )
+
+  serviceWithETHCreatedEvent.parameters.push(
+    new ethereum.EventParam('nonce', ethereum.Value.fromUnsignedBigInt(nonce))
+  )
+  serviceWithETHCreatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'serviceType',
+      ethereum.Value.fromString(serviceType)
+    )
+  )
+  serviceWithETHCreatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'visibilityId',
+      ethereum.Value.fromString(visibilityId)
+    )
+  )
+  serviceWithETHCreatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'buyBackCreditsShare',
+      ethereum.Value.fromUnsignedBigInt(buyBackCreditsShare)
+    )
+  )
+  serviceWithETHCreatedEvent.parameters.push(
+    new ethereum.EventParam(
+      'weiCostAmount',
+      ethereum.Value.fromUnsignedBigInt(weiCostAmount)
+    )
+  )
+
+  return serviceWithETHCreatedEvent
 }
 
 export function createServiceExecutionAcceptedEvent(

--- a/tests/visibility-services-utils.ts
+++ b/tests/visibility-services-utils.ts
@@ -291,6 +291,7 @@ export function createServiceExecutionDisputedEvent(
 
 export function createServiceExecutionEthPaymentEvent(
   serviceNonce: BigInt,
+  executionNonce: BigInt,
   protocolAmount: BigInt,
   creatorAmount: BigInt,
   buyBackAmount: BigInt
@@ -304,6 +305,12 @@ export function createServiceExecutionEthPaymentEvent(
     new ethereum.EventParam(
       'serviceNonce',
       ethereum.Value.fromUnsignedBigInt(serviceNonce)
+    )
+  )
+  serviceExecutionEthPaymentEvent.parameters.push(
+    new ethereum.EventParam(
+      'executionNonce',
+      ethereum.Value.fromUnsignedBigInt(executionNonce)
     )
   )
   serviceExecutionEthPaymentEvent.parameters.push(

--- a/tests/visibility-services-utils.ts
+++ b/tests/visibility-services-utils.ts
@@ -9,6 +9,7 @@ import {
   ServiceExecutionAccepted,
   ServiceExecutionCanceled,
   ServiceExecutionDisputed,
+  ServiceExecutionEthPayment,
   ServiceExecutionInformation,
   ServiceExecutionRequested,
   ServiceExecutionResolved,
@@ -286,6 +287,45 @@ export function createServiceExecutionDisputedEvent(
   )
 
   return serviceExecutionDisputedEvent
+}
+
+export function createServiceExecutionEthPaymentEvent(
+  serviceNonce: BigInt,
+  protocolAmount: BigInt,
+  creatorAmount: BigInt,
+  buyBackAmount: BigInt
+): ServiceExecutionEthPayment {
+  let serviceExecutionEthPaymentEvent =
+    changetype<ServiceExecutionEthPayment>(newMockEvent())
+
+  serviceExecutionEthPaymentEvent.parameters = new Array()
+
+  serviceExecutionEthPaymentEvent.parameters.push(
+    new ethereum.EventParam(
+      'serviceNonce',
+      ethereum.Value.fromUnsignedBigInt(serviceNonce)
+    )
+  )
+  serviceExecutionEthPaymentEvent.parameters.push(
+    new ethereum.EventParam(
+      'protocolAmount',
+      ethereum.Value.fromUnsignedBigInt(protocolAmount)
+    )
+  )
+  serviceExecutionEthPaymentEvent.parameters.push(
+    new ethereum.EventParam(
+      'creatorAmount',
+      ethereum.Value.fromUnsignedBigInt(creatorAmount)
+    )
+  )
+  serviceExecutionEthPaymentEvent.parameters.push(
+    new ethereum.EventParam(
+      'buyBackAmount',
+      ethereum.Value.fromUnsignedBigInt(buyBackAmount)
+    )
+  )
+
+  return serviceExecutionEthPaymentEvent
 }
 
 export function createServiceExecutionInformationEvent(

--- a/tests/visibility-services.test.ts
+++ b/tests/visibility-services.test.ts
@@ -255,6 +255,7 @@ describe('VisibilityServices', () => {
 
     let newEthPaymentEvent = createServiceExecutionEthPaymentEvent(
       servNonce2,
+      execNonce21,
       BigInt.fromI32(1000),
       BigInt.fromI32(1000),
       BigInt.fromI32(1000)

--- a/tests/visibility-services.test.ts
+++ b/tests/visibility-services.test.ts
@@ -16,6 +16,7 @@ import {
   createServiceExecutionAcceptedEvent,
   createServiceExecutionCanceledEvent,
   createServiceExecutionDisputedEvent,
+  createServiceExecutionEthPaymentEvent,
   createServiceExecutionInformationEvent,
   createServiceExecutionRequestedEvent,
   createServiceExecutionResolvedEvent,
@@ -31,6 +32,7 @@ import {
   handleServiceExecutionAccepted,
   handleServiceExecutionCanceled,
   handleServiceExecutionDisputed,
+  handleServiceExecutionEthPayment,
   handleServiceExecutionInformation,
   handleServiceExecutionRequested,
   handleServiceExecutionResolved,
@@ -250,6 +252,16 @@ describe('VisibilityServices', () => {
     let newServiceExecutionValidatedEvent =
       createServiceExecutionValidatedEvent(servNonce2, execNonce21)
     handleServiceExecutionValidated(newServiceExecutionValidatedEvent)
+
+    let newEthPaymentEvent = createServiceExecutionEthPaymentEvent(
+      servNonce2,
+      BigInt.fromI32(1000),
+      BigInt.fromI32(1000),
+      BigInt.fromI32(1000)
+    )
+    handleServiceExecutionEthPayment(newEthPaymentEvent)
+
+    assert.entityCount('ServiceExecutionEthPayment', 1)
 
     let newBuyBackPoolEvent = createBuyBackPoolUpdatedEvent(
       visibilityId,


### PR DESCRIPTION
## Scope

This update ensures better tracking of ETH-based payments and buyback mechanisms within the subgraph.

## **Updated Entities**  

### **Visibility**  
- `buyBackEthBalance`: Tracks the amount of ETH available for buybacks.  
- `buyBacks`: Stores entities linked to all buyback events.  

### **VisibilityServices**  
- `paymentType`: Specifies the payment method (`VISIBILITY_CREDITS` or `ETH`).  
- `weiCostAmount`: Stores the ETH cost if the service is paid in ETH.  
- `buyBackCreditsShare`: Percentage of ETH payment allocated to the buyback pool when the service is validated.  
- `serviceExecutionEthPayments` : Wei amounts sent to the protocol, the creator and to the buy back pool on a service execution validation. 
